### PR TITLE
add about page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,7 @@
       <a href="code.html" class="btn">Code</a>
       <a href="using.html" class="btn">Use</a>
       <a href="learning.html" class="btn">Learn</a>
+      <a href="about.html" class="btn">About</a>
 
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>

--- a/about.md
+++ b/about.md
@@ -1,0 +1,26 @@
+---
+layout: default
+---
+
+The *aosp-devs* group was founded in late 2024. The founding members are (in
+alphabetical order):
+
+* Amit Pundir
+* Chris Simmonds
+* Mattijs Korpershoek
+* Mishaal Rahman
+* Stefan Lengfeld
+* Sumit Semwal
+
+
+## Contact
+
+If you want to contact us, you can
+
+* reach us on the [discord server](https://discord.gg/hH59SPKYv8) or
+* send a email to [aosp-devs@groups.io](mailto:aosp-devs@groups.io)
+
+
+## Additional resources
+
+Here you can read our [code of conduct (CoC)](code-of-conduct).


### PR DESCRIPTION
Add about page with founding members and disclaimer.

![image](https://github.com/user-attachments/assets/fa380367-e1b1-444d-876f-d478098c6910)
