### PR TITLE
Update Mediatek board name

### DIFF
--- a/code.md
+++ b/code.md
@@ -23,7 +23,7 @@ adds support to upstream AOSP for several boards including:
 
 BayLibre have support packages for
 
-* MediaTek MT8365 (i350): [https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html](https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html)
+* MediaTek Genio 350-EVK: [https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html](https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html)
 * Texas Instruments AM62X and AM62PX: [https://baylibre.pages.baylibre.com/ti/android/doc/ti-android-15/index.html](https://baylibre.pages.baylibre.com/ti/android/doc/ti-android-15/index.html)
 
 Other projects:


### PR DESCRIPTION
Mediatek has changed the name of their AIOT boards.

Rename the supported board to its new name: genio 350-evk.