### PR TITLE
Rename 'News' to 'Newsletter'

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
       <a href="/code.html" class="btn">Code</a>
       <a href="/using.html" class="btn">Use</a>
       <a href="/learning.html" class="btn">Learn</a>
-      <a href="/newsletter.html" class="btn">News</a>
+      <a href="/newsletter.html" class="btn">Newsletter</a>
       <a href="/about.html" class="btn">About</a>
 
       {% if site.show_downloads %}


### PR DESCRIPTION
It confuses readers of the homepage. If someone is searching for the newsletter on the homepage, he/she should directly see the right submenu.