### PR TITLE
Add MediaTek Genio 700 and 510 EVKs to BayLibre BSP support

### DIFF
--- a/code.md
+++ b/code.md
@@ -32,7 +32,7 @@ adds support to upstream AOSP for several boards including:
 
 BayLibre have support packages for:
 
-* MediaTek Genio 700, 510 and 350 EVKs: [https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html](https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html)
+* MediaTek Genio 700, 510 and 350 EVKs: [https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek](https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek)
 * Texas Instruments AM62X and AM62PX: [https://baylibre.pages.baylibre.com/ti/android/doc/ti-android-15/index.html](https://baylibre.pages.baylibre.com/ti/android/doc/ti-android-15/index.html)
 
 Other projects:

--- a/code.md
+++ b/code.md
@@ -30,9 +30,9 @@ adds support to upstream AOSP for several boards including:
 * Snapdragon(tm) 8 Gen 2 Mobile Hardware Development Kit (HDK 8550)
 * Hikey 960
 
-BayLibre have support packages for
+BayLibre have support packages for:
 
-* MediaTek Genio 350-EVK: [https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html](https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html)
+* MediaTek Genio 700, 510 and 350 EVKs: [https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html](https://baylibre.pages.baylibre.com/mediatek/rita/device/mediatek/boards/mtk-android-14/index.html)
 * Texas Instruments AM62X and AM62PX: [https://baylibre.pages.baylibre.com/ti/android/doc/ti-android-15/index.html](https://baylibre.pages.baylibre.com/ti/android/doc/ti-android-15/index.html)
 
 Other projects:


### PR DESCRIPTION
BayLibre BSP now supports Genio 700 and Genio 510 EVKs.

Add them to the list of supported boards.
