### PR TITLE
Avoid posthog for local deployment

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -6,5 +6,9 @@
         defaults: '2025-05-24',
         persistence: 'memory',
     })
+    if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname == "[::1]") {
+        posthog.opt_out_capturing()
+        console.log("Opt out capturing for local developments!");
+    }
     </script>
     <link rel="stylesheet" href="{{ '/assets/css/custom.css?v=' | append: site.github.build_revision | relative_url }}">


### PR DESCRIPTION
We don't want to have the local test deployments be tracked in the posthog analytics. This waters the numbers.

So add some javascript code to disable capturing for local deployments. It's easier to do it here than to make filters on posthog.

I have taken the code from

    https://posthog.com/tutorials/multiple-environments#opt-out-of-capturing-based-on-url

but also added support for IPv6.