### PR TITLE
Convert newsletter pages to blog posts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,6 @@
       <a href="/blog.html" class="btn">Blog</a>
       <a href="/reference.html" class="btn">Library</a>
       <a href="/calendar.html" class="btn">Calendar</a>
-      <a href="/newsletter.html" class="btn">Newsletter</a>
       <a href="/about.html" class="btn">About</a>
 
       {% if site.show_downloads %}

--- a/_layouts/newsletter.html
+++ b/_layouts/newsletter.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<h1>{{ page.title }}</h1>
+
+{{ content }}

--- a/blog.md
+++ b/blog.md
@@ -4,6 +4,8 @@ layout: default
 
 <h1>Blog posts</h1>
 
+The blog posts are also availabe as a [RSS feed](/feed.xml):
+
 <ul>
   {% for post in site.posts %}
     <li>
@@ -12,5 +14,3 @@ layout: default
     </li>
   {% endfor %}
 </ul>
-
-The blog posts are also availabe as a [RSS feed](/feed.xml).

--- a/index.md
+++ b/index.md
@@ -7,12 +7,34 @@ The Android Open Source Project (AOSP) is used globally to power devices of
 all shapes and sizes, not just phones but also exercise bikes and oscilloscopes.
 aosp-devs.org is here to help the people working with AOSP to create those devices
 
-## Come chat with us
+## Join us
 
-We have a Discord server for discussion. Click [here](https://discord.gg/hH59SPKYv8) to join us.
+We have a Discord server for discussion. Click the button to join us.
+
+<a href="https://discord.gg/hH59SPKYv8" style="background-color: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; display: inline-block">Join the Discord server</a>
+
+Or join one of the online or on-site events. See our [calendar](/calendar/).
 
 
-## Aims
+## What we do?
+
+We organize and create a couple of things:
+
+* We run the above mentioned Discord server.
+* We maintain this website and occasionally publish a blog post on [blog](/blog/).
+* We publish a monthly newsletter since January 2025. They are posted also to our [blog](/blog/).
+* We run the [AOSP and AAOS Meetup](https://aospandaaos.github.io/) that was started by Chris Simmonds in 2022.
+* We organized the [AOSP Devroom in 2025](https://fosdem.org/2025/schedule/track/aosp/) and
+  helped to organize the [FOSS on Mobile devroom 2026](https://fosdem.org/2026/schedule/track/foss-on-mobile/) at
+  [FOSDEM](https://fosdem.org/). Also we organized the [AOSP devroom 2025](https://fossunited.org/indiafoss/2025/devrooms/aosp)
+  at [IndiaFOSS](https://fossunited.org/indiafoss/2025).
+* We maintain a [calendar](/calendar/) with AOSP releated on-site and online events.
+* We are active on social media [Linkedin (@aosp-devs)](https://www.linkedin.com/company/aosp-devs/) and
+  [mastodon (@aosp_devs)](https://androiddev.social/@aosp_devs) and on [github account (@aosp-devs)](https://github.com/aosp-devs).
+  Feel free to follow us!
+
+
+## What we aim for?
 
 * Reduce the fragmentation in the AOSP ecosystem by sharing code, tooling, and knowledge
 * Provide a repository for documentation, tutorials, and best practices
@@ -23,12 +45,6 @@ We have a Discord server for discussion. Click [here](https://discord.gg/hH59SPK
 * Provide education
 * Provide a conduit between Google, the AOSP community, and OEMs
 
-
-## Social media and github
-
-We are on [Linkedin (@aosp-devs)](https://www.linkedin.com/company/aosp-devs/),
-on [mastodon (@aosp_devs)](https://androiddev.social/@aosp_devs),
-and we have a [github account (@aosp-devs)](https://github.com/aosp-devs). Feel free to follow!
 
 ## Meetings
 
@@ -55,7 +71,7 @@ Recordings are available on the FOSDEM website on the individual talk pages.
 The devroom was a great success. We would like to thank all the speakers, the
 devroom organisers and the people who came along to watch, listen and take part in the discussion.
 
-All of the talks are online now in our YouTube channel, 
+All of the talks are online now in our YouTube channel,
 <https://www.youtube.com/@aosp-devs>.
 
 In addition, you can go to the FOSDEM event page, <https://fosdem.org/2025/schedule/track/aosp/>,

--- a/newsletter.md
+++ b/newsletter.md
@@ -6,38 +6,10 @@ layout: default
 
 List of all published newsletters (latest at the top):
 
-[2026 June Newsletter](newsletter/2026-june.html)
-
-[2026 May Newsletter](newsletter/2026-may.html)
-
-[2026 April Newsletter](newsletter/2026-april.html)
-
-[2026 March Newsletter](newsletter/2026-march.html)
-
-[2026 February Newsletter](newsletter/2026-february.html)
-
-[2026 January Newsletter](newsletter/2026-january.html)
-
-[2025 December Newsletter](newsletter/2025-december.html)
-
-[2025 November Newsletter](newsletter/2025-november.html)
-
-[2025 October Newsletter](newsletter/2025-october.html)
-
-[2025 September Newsletter](newsletter/2025-september.html)
-
-[2025 August Newsletter](newsletter/2025-august.html)
-
-[2025 July Newsletter](newsletter/2025-july.html)
-
-[2025 June Newsletter](newsletter/2025-june.html)
-
-[2025 May Newsletter](newsletter/2025-may.html)
-
-[2025 April Newsletter](newsletter/2025-april.html)
-
-[2025 March Newsletter](newsletter/2025-march.html)
-
-[2025 February Newsletter](newsletter/2025-february.html)
-
-[2025 January Newsletter](newsletter/2025-january.html)
+{% for post in site.posts %}
+{% if post.categories contains "newsletter" %}
+<p>
+  <a href="{{ post.url }}">{{ post.date | date: "%Y" }} {{ post.title }}</a>
+</p>
+{% endif %}
+{% endfor %}

--- a/newsletter/_posts/2025-01-31-x.md
+++ b/newsletter/_posts/2025-01-31-x.md
@@ -1,11 +1,14 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-january:output_ext
+title: January Newsletter
 ---
-
-# aosp-devs.org January Newsletter
 
 Welcome to the first aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
+
+<!--more-->
 
 ## New Blogposts
 

--- a/newsletter/_posts/2025-02-31-x.md
+++ b/newsletter/_posts/2025-02-31-x.md
@@ -1,13 +1,15 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-february:output_ext
+title: February Newsletter
 ---
-
-# aosp-devs.org February Newsletter
 
 Welcome to the second aosp-devs newsletter, keeping you up to date with things happening in the AOSP developer community.
 
 Perhaps the most important thing to mention is that we held our first AOSP devroom at FOSDEM. We believe it was a great success! The recordings are now available on our new YouTube channel: [@aosp-devs](https://www.youtube.com/@aosp-devs). Enjoy watching!
 
+<!--more-->
 
 ## New Blogposts and Media
 

--- a/newsletter/_posts/2025-03-31-x.md
+++ b/newsletter/_posts/2025-03-31-x.md
@@ -1,10 +1,13 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-march:output_ext
+title: March Newsletter
 ---
 
-# aosp-devs.org March Newsletter
-
 Welcome to the third aosp-devs newsletter, keeping you up to date with things happening in the AOSP developer community.
+
+<!--more-->
 
 ## Updates to the AOSP development workflow by Google
 

--- a/newsletter/_posts/2025-04-31-x.md
+++ b/newsletter/_posts/2025-04-31-x.md
@@ -1,8 +1,9 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-april:output_ext
+title: April Newsletter
 ---
-
-# aosp-devs.org April newsletter
 
 Welcome to the fourth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
@@ -10,6 +11,7 @@ happening in the AOSP developer community.
 It may be becoming a tradition that the newsletter is released a bit later,
 rather than at the end of the month. :-)
 
+<!--more-->
 
 ## New on LinkedIn
 

--- a/newsletter/_posts/2025-05-31-x.md
+++ b/newsletter/_posts/2025-05-31-x.md
@@ -1,14 +1,17 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-may:output_ext
+title: May Newsletter
 ---
-
-# aosp-devs.org May newsletter
 
 Welcome to the fifth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
 
 The tradition continues. The May newsletter is released again two days too
 late.
+
+<!--more-->
 
 ## AOSP devroom at IndiaFOSS 2025
 

--- a/newsletter/_posts/2025-06-31-x.md
+++ b/newsletter/_posts/2025-06-31-x.md
@@ -1,14 +1,17 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-june:output_ext
+title: June Newsletter
 ---
-
-# aosp-devs.org June newsletter
 
 Welcome to the sixth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
 
 The tradition continues, again and again. The June newsletter is released two
 days too late.
+
+<!--more-->
 
 ## Android 16 released
 

--- a/newsletter/_posts/2025-07-31-x.md
+++ b/newsletter/_posts/2025-07-31-x.md
@@ -1,8 +1,9 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-july:output_ext
+title: July Newsletter
 ---
-
-# aosp-devs.org July newsletter
 
 Welcome to the seventh aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
@@ -10,6 +11,8 @@ happening in the AOSP developer community.
 It's already August and summer time in the northern hemisphere. So vacation
 time for some people and therefore no excuse to release the newsletter on time.
 Again it's two days too late. Enjoy.
+
+<!--more-->
 
 
 ## The libraries page

--- a/newsletter/_posts/2025-08-31-x.md
+++ b/newsletter/_posts/2025-08-31-x.md
@@ -1,13 +1,16 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-august:output_ext
+title: August Newsletter
 ---
-
-# aosp-devs.org August newsletter
 
 Welcome to the eighth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
 
 And … again three days too late. Who would have thought that?
+
+<!--more-->
 
 
 ## Upcoming changes by Google for Application sideloading

--- a/newsletter/_posts/2025-09-31-x.md
+++ b/newsletter/_posts/2025-09-31-x.md
@@ -1,14 +1,17 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-september:output_ext
+title: September Newsletter
 ---
-
-# aosp-devs.org September newsletter
 
 Welcome to the ninth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community. September started slowly, but
 picked up speed with events and news to the end.
 
 Nevertheless, the newsletter is late, late, late ... and late.
+
+<!--more-->
 
 
 ## Upcoming changes by Google for Application sideloading

--- a/newsletter/_posts/2025-10-31-x.md
+++ b/newsletter/_posts/2025-10-31-x.md
@@ -1,13 +1,16 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-october:output_ext
+title: October Newsletter
 ---
-
-# aosp-devs.org October newsletter
 
 Welcome to the tenth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
 
 Since the newsletter is not on-time (again), it misses halloweeeeeeen.
+
+<!--more-->
 
 
 ## News update about the Application Sideloading Changes

--- a/newsletter/_posts/2025-11-31-x.md
+++ b/newsletter/_posts/2025-11-31-x.md
@@ -1,14 +1,17 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-november:output_ext
+title: November Newsletter
 ---
-
-# aosp-devs.org November newsletter
 
 Welcome to the eleventh aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
 
 New record: 6 days too late, but ... we are busy organizing the devroom at
 FOSDEM'26.
+
+<!--more-->
 
 
 ## FOSDEM`26

--- a/newsletter/_posts/2025-12-31-x.md
+++ b/newsletter/_posts/2025-12-31-x.md
@@ -1,13 +1,16 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-december:output_ext
+title: December Newsletter
 ---
-
-# aosp-devs.org December newsletter
 
 Welcome to the twelfth aosp-devs newsletter, keeping you up to date with things
 happening in the AOSP developer community.
 
 Again, too late. But right on time to wish everyone a happy new year.
+
+<!--more-->
 
 
 ## FOSDEM'26 - FOSS on Mobile devroom

--- a/newsletter/_posts/2026-01-31-x.md
+++ b/newsletter/_posts/2026-01-31-x.md
@@ -1,14 +1,17 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-january:output_ext
+title: January Newsletter
 ---
-
-# aosp-devs.org January newsletter
 
 Welcome to the thirteenth aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
 
 It's not too late. Actually, it's quite timely, since on the weekend there was FOSDEM
 fulltime.
+
+<!--more-->
 
 
 ## FOSDEM'26 - FOSS on Mobile devroom

--- a/newsletter/_posts/2026-02-31-x.md
+++ b/newsletter/_posts/2026-02-31-x.md
@@ -1,13 +1,16 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-february:output_ext
+title: February Newsletter
 ---
-
-# aosp-devs.org February newsletter
 
 Welcome to the fourteenth aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
 
 We are back to normal, 6 days too late without excuses.
+
+<!--more-->
 
 
 ## Security updates and AAOS release

--- a/newsletter/_posts/2026-03-31-x.md
+++ b/newsletter/_posts/2026-03-31-x.md
@@ -1,13 +1,16 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-march:output_ext
+title: March Newsletter
 ---
-
-# aosp-devs.org March newsletter
 
 Welcome to the fifteenth aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
 
 Just two days too late to avoid the April Fools' Day.
+
+<!--more-->
 
 
 ## New calendar page on aosp-devs.org

--- a/newsletter/_posts/2026-04-31-x.md
+++ b/newsletter/_posts/2026-04-31-x.md
@@ -1,13 +1,16 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-april:output_ext
+title: April Newsletter
 ---
-
-# aosp-devs.org April newsletter
 
 Welcome to the sixteenth aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
 
 Just four days too late. New record?
+
+<!--more-->
 
 
 ## New blog post on aosp-devs.org

--- a/newsletter/_posts/2026-05-31-x.md
+++ b/newsletter/_posts/2026-05-31-x.md
@@ -1,14 +1,17 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-may:output_ext
+title: May Newsletter
 ---
-
-# May newsletter
 
 Welcome to the seventeenth aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
 
 Just a bit … two days too late. But I would say it was worth the wait. May was
 the month of AI for AOSP. Read on!
+
+<!--more-->
 
 
 ## May AOSP and AAOS Meetup - Recordings online

--- a/newsletter/_posts/2026-06-31-x.md
+++ b/newsletter/_posts/2026-06-31-x.md
@@ -1,8 +1,9 @@
 ---
-layout: default
+layout: newsletter
+excerpt_separator: <!--more-->
+permalink: /:categories/:year-may:output_ext
+title: June Newsletter
 ---
-
-# June newsletter
 
 Welcome to the eighteenth aosp-devs newsletter, keeping you up to date with
 things happening in the AOSP developer community.
@@ -10,6 +11,7 @@ things happening in the AOSP developer community.
 Three days too late. But at least in the northern hemisphere, it's summertime.
 So it is time to relax and take a break.
 
+<!--more-->
 
 ## Android 17 is out!
 


### PR DESCRIPTION
Summary:

* The URLs/paths to the newsletter posts are kept 100% identical. Don't break external links!
* The menu item "newsletter" is removed. We have already a lot of menu items. It's not mentioned on the index/start page.
* Move the RSS notice from the bottom of the blog post page to the top. So it's still visible when there are a lot of blog posts
* Rework the start/home page to make more visible what we do.

Here a screenshot of the new landing start/page
<img width="1239" height="892" alt="image" src="https://github.com/user-attachments/assets/66641496-c614-44b8-ae75-f14dc3f60c3b" />

And here the blogpost page with the newsletters:

<img width="1239" height="892" alt="image" src="https://github.com/user-attachments/assets/219676b5-836c-40c7-85a6-e71f231e2271" />
