### PR TITLE
docs: add local Docker run instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 _site/
+.bundle/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+Gemfile.lock
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "jekyll", "4.2.2"
+gem "jekyll-sass-converter", "~> 2.1"
+gem "jekyll-theme-cayman"
+gem "jekyll-feed"
+gem "sassc", "~> 2.4"
+gem "webrick", "~> 1.8"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ aosp-devs is a community for AOSP Developers.
 
 This repository contains the contents of the website [aosp-devs.org](https://aosp-devs.org).
 Contributions are welcome. Feel free to open a PR.
+
+## Run locally
+
+```bash
+docker run --rm \
+  --name aosp-devs.org \
+  -p 4000:4000 \
+  -p 35729:35729 \
+  -v "$PWD:/srv/jekyll" \
+  -v "$PWD/vendor/bundle:/usr/local/bundle" \
+  -it \
+  jekyll/jekyll:4 \
+  bash -lc 'bundle install && bundle exec jekyll serve --host 0.0.0.0 --livereload'
+```
+
+Open `http://127.0.0.1:4000`.


### PR DESCRIPTION
## Summary

Add Docker-based local Jekyll run instructions and the minimal Gemfile needed to run the site without installing Ruby dependencies on the host.

## Test

```bash
docker run --rm \
  --name aosp-devs.org \
  -p 4000:4000 \
  -p 35729:35729 \
  -v "$PWD:/srv/jekyll" \
  -v "$PWD/vendor/bundle:/usr/local/bundle" \
  -it \
  jekyll/jekyll:4 \
  bash -lc 'bundle install && bundle exec jekyll serve --host 0.0.0.0 --livereload'
```

Open http://127.0.0.1:4000